### PR TITLE
Travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: cpp
 
-sudo: false
+# Generating core dumps requires a sudo machine
+# https://github.com/travis-ci/travis-ci/issues/3754
+sudo: true
 
 addons:
  apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,18 +23,13 @@ before_script:
  - ulimit -c unlimited -S
 
 script:
- - RESULT=0
  # Compile our demo program which will crash if
  # the CRASH_PLEASE environment variable is set (to anything)
  - make
  # Run the program to prompt a crash
- # Note: we capture the return code of the program here and add
- # `|| true` to ensure that travis continues past the crash
- - ./test || RESULT=$?
- - if [[ ${RESULT} == 0 ]]; then echo "\\o/ our test worked without problems"; else echo "ruhroh test returned an errorcode of $RESULT"; fi;
+ - ./test
+
+after_failure:
  # If the program returned an error code, now we check for a
  # core file in the current working directory and dump the backtrace out
  - for i in $(find ./ -maxdepth 1 -name 'core*' -print); do gdb $(pwd)/test core* -ex "thread apply all bt" -ex "set pagination 0" -batch; done;
- # now we should present travis with the original
- # error code so the run cleanly stops
- - if [[ ${RESULT} != 0 ]]; then exit $RESULT ; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: cpp
 
+sudo: false
+
+addons:
+ apt:
+  packages:
+  - gdb
+
 env:
   matrix:
    - CRASH_PLEASE=boooooooom
@@ -8,10 +15,6 @@ env:
 compiler:
  # gcc compiler, clang would be fine too
  - gcc
-
-before_install:
- # install the gnu debugger for later use in reading the core file
- - sudo apt-get -y install gdb
 
 install:
  # What is the current file size max for core files?


### PR DESCRIPTION
- Use `after_failure` to greatly simplify logic
- Use containterized builds for faster builds

(still needs "testing" on travis)
