### PR TITLE
Sudo false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
   apt:
     packages:
      - gdb
+     - apport
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: cpp
 
+sudo: false
+
+addons:
+  apt:
+    packages:
+     - gdb
+
 env:
   matrix:
    - CRASH_PLEASE=boooooooom
@@ -10,20 +17,25 @@ compiler:
  - gcc
 
 before_install:
- # install the gnu debugger for later use in reading the core file
- - sudo apt-get -y install gdb
-
-install:
  # What is the current file size max for core files?
  # It is usually 0, which means no core file will be dumped if there is a crash 
  - ulimit -c
+ - ulimit -a -S
+ - ulimit -a -H
 
-before_script:
+install:
  # Set the core file limit to unlimited so a core file is generated upon crash
  - ulimit -c unlimited -S
+ - ulimit -c
+ - ulimit -a -S
+ - ulimit -a -H
+ - cat /proc/sys/kernel/core_pattern
+ #- echo "core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
+
+before_script:
+ - RESULT=0
 
 script:
- - RESULT=0
  # Compile our demo program which will crash if
  # the CRASH_PLEASE environment variable is set (to anything)
  - make
@@ -31,6 +43,7 @@ script:
  # Note: we capture the return code of the program here and add
  # `|| true` to ensure that travis continues past the crash
  - ./test || RESULT=$?
+ - ls -l
  - if [[ ${RESULT} == 0 ]]; then echo "\\o/ our test worked without problems"; else echo "ruhroh test returned an errorcode of $RESULT"; fi;
  # If the program returned an error code, now we check for a
  # core file in the current working directory and dump the backtrace out


### PR DESCRIPTION
This change starts using the `sudo:false` docker machines. This originally did not work per https://github.com/travis-ci/travis-ci/issues/3754 but now does with the addition of `apport` apt-package.